### PR TITLE
feat(projects,ui): add Load Project workflow; activate tabs on projec…

### DIFF
--- a/tests/test_importers/test_callout_importer.py
+++ b/tests/test_importers/test_callout_importer.py
@@ -39,5 +39,6 @@ def test_callout_importer_parses_json_correctly(mocker):
 
     importer = CalloutImporter()
     callouts = importer.parse_json_file("dummy_path.json")
+    print(callouts)
 
     assert callouts == expected_callouts


### PR DESCRIPTION
…t selection

- ProjectsTab:
  - Add "Load Project" button next to "Import from Innergy"
  - Wire double‑click and Load Project button to emit open_project_signal for the selected project
  - Support both row and single‑cell selection when loading
  - Show project details view on load
- MainWindow:
  - Introduce current_project and current_project_changed signal
  - Cache tab indexes and disable Attributes, Workspace, and Export tabs by default
  - Enable tabs upon project load via ProjectsTab.open_project_signal
  - Keep Projects tab always enabled; surface refresh action unchanged

Why:
- Prevent editing/export actions until a project is explicitly selected
- Provide an explicit control to load a project in addition to double‑click

Refs: UI activation requirements; project selection workflow